### PR TITLE
Review GitHub Actions Permission and Other Fix

### DIFF
--- a/.github/workflows/cmake-build-test.yml
+++ b/.github/workflows/cmake-build-test.yml
@@ -1,7 +1,8 @@
 # Test if libyt can build with different options, download dependencies, and install and link correctly.
 
 name: build test
-
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/example-test-run.yml
+++ b/.github/workflows/example-test-run.yml
@@ -1,7 +1,8 @@
 # Test if example can run on multiplatform and both in serial (gcc) and parallel (openmpi)
 
 name: amr example
-
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -1,5 +1,6 @@
 name: memory profile
-
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,7 +2,8 @@
 # Also upload the code coverage report to codecov
 
 name: unit test
-
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]

--- a/src/yt_run_InteractiveMode.cpp
+++ b/src/yt_run_InteractiveMode.cpp
@@ -3,10 +3,10 @@
 #include "timer.h"
 
 #ifdef INTERACTIVE_MODE
-#include <cstdio>
 #include <readline/readline.h>
 
 #include <cctype>
+#include <cstdio>
 #include <iostream>
 #include <string>
 

--- a/src/yt_run_InteractiveMode.cpp
+++ b/src/yt_run_InteractiveMode.cpp
@@ -3,6 +3,7 @@
 #include "timer.h"
 
 #ifdef INTERACTIVE_MODE
+#include <cstdio>
 #include <readline/readline.h>
 
 #include <cctype>

--- a/src/yt_run_ReloadScript.cpp
+++ b/src/yt_run_ReloadScript.cpp
@@ -3,6 +3,7 @@
 #include "timer.h"
 
 #ifdef INTERACTIVE_MODE
+#include <cstdio>
 #include <readline/readline.h>
 
 #include <chrono>

--- a/src/yt_run_ReloadScript.cpp
+++ b/src/yt_run_ReloadScript.cpp
@@ -3,10 +3,10 @@
 #include "timer.h"
 
 #ifdef INTERACTIVE_MODE
-#include <cstdio>
 #include <readline/readline.h>
 
 #include <chrono>
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
## Review GitHub Actions Permission

After setting GitHub Actions workflow permission to **Read repository contents and packages permissions**, I need to check what permission to grant to each workflow.

## Other Fix

- Include `cstdio` before `readline` library.
  - This issue is first found in fedora, while I was setting up my new laptop. ([ref](https://stackoverflow.com/questions/28008167/errors-when-trying-to-build-in-cygwin))
